### PR TITLE
Add language

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -72,6 +72,22 @@ i.mce-i-icon-book:before {
   text-decoration: inherit;
 }
 
+i.mce-i-icon-double-arrow:before {
+  content: '\f103';
+  font-family: FontAwesome;
+  font-style: normal;
+  font-weight: normal;
+  text-decoration: inherit;
+}
+
+i.mce-i-icon-arrow:before {
+  content: '\f107';
+  font-family: FontAwesome;
+  font-style: normal;
+  font-weight: normal;
+  text-decoration: inherit;
+}
+
 li.disabled {
   pointer-events: none;
   opacity: 0.6;
@@ -125,8 +141,8 @@ a.uneditable {
   }
   h4 {
     font-size: 13px;
-    border-top: solid #4f818d 1px;
-    border-left: solid #4f818d 1px;
+    border-top: dashed #4f818d 1px;
+    border-left: dashed #4f818d 1px;
     padding: 3px;
     color: #4f818d;
   }

--- a/app/assets/stylesheets/export.scss
+++ b/app/assets/stylesheets/export.scss
@@ -64,7 +64,7 @@
     margin-top: 25px;
   }
 
-  .japanese, .english {
+  .ja, .en {
     margin: 15px 0px;
   }
 }

--- a/app/assets/stylesheets/export.scss
+++ b/app/assets/stylesheets/export.scss
@@ -54,8 +54,8 @@
     }
     h4 {
       font-size: 13px;
-      border-top: solid #4f818d 1px;
-      border-left: solid #4f818d 1px;
+      border-top: dashed #4f818d 1px;
+      border-left: dashed #4f818d 1px;
       padding: 3px;
     }
   }

--- a/app/assets/stylesheets/export.scss
+++ b/app/assets/stylesheets/export.scss
@@ -63,4 +63,8 @@
   .mt-xl {
     margin-top: 25px;
   }
+
+  .japanese, .english {
+    margin: 15px 0px;
+  }
 }

--- a/app/controllers/protocols_controller.rb
+++ b/app/controllers/protocols_controller.rb
@@ -63,6 +63,9 @@ class ProtocolsController < ApplicationController
     @protocol.short_title = "#{original.short_title} - (COPY)" if original.short_title.present?
   end
 
+  def select
+  end
+
   def export
     @content_0 = @protocol.contents.find_by(no: '0')
     @contents = @protocol.contents.where.not(no: '0').sort_by { |c| c.no.to_f }

--- a/app/javascript/packs/main.js
+++ b/app/javascript/packs/main.js
@@ -67,12 +67,6 @@ $(() => {
     checkFile();
   }
 
-  // protocol export
-  $("input[name='export_type']").change((e) => {
-    $('.export-pdf-button').attr('href', `${$('.export-pdf-button').data('url')}?type=${$(e.target).val()}`);
-    $('.export-docx-button').attr('href', `${$('.export-docx-button').data('url')}?type=${$(e.target).val()}`);
-  });
-
   // contents
   const hash = window.location.hash;
   hash && $('ul.nav a[href="' + hash + ']').tab('show');

--- a/app/javascript/packs/main.js
+++ b/app/javascript/packs/main.js
@@ -67,6 +67,12 @@ $(() => {
     checkFile();
   }
 
+  // protocol export
+  $("input[name='export_type']").change((e) => {
+    $('.export-pdf-button').attr('href', `${$('.export-pdf-button').data('url')}?type=${$(e.target).val()}`);
+    $('.export-docx-button').attr('href', `${$('.export-docx-button').data('url')}?type=${$(e.target).val()}`);
+  });
+
   // contents
   const hash = window.location.hash;
   hash && $('ul.nav a[href="' + hash + ']').tab('show');

--- a/app/javascript/packs/protocol.jsx
+++ b/app/javascript/packs/protocol.jsx
@@ -27,26 +27,17 @@ class Protocol extends React.Component {
           </td>
           <td>
             {(() => {
-              if (data.export_pdf_url.length > 0) {
+              if (data.export_url.length > 0) {
                 return (
-                  <a href={data.export_pdf_url} className='btn btn-default' target='_blank' onClick={(e) => { this.onClick(e) }}>
+                  <a href={data.export_url} className='btn btn-default' onClick={(e) => { this.onClick(e) }}>
                     {this.props.buttons[1]}
-                  </a>
-                );
-              }
-            })()}
-            {(() => {
-              if (data.export_docx_url.length > 0) {
-                return (
-                  <a href={data.export_docx_url} className='btn btn-default ml-s' target='_blank' onClick={(e) => { this.onClick(e) }}>
-                    {this.props.buttons[2]}
                   </a>
                 );
               }
             })()}
           </td>
           <td>
-            <a href={data.clone_url} className='btn btn-default' onClick={(e) => { this.onClick(e) }}>{this.props.buttons[3]}</a>
+            <a href={data.clone_url} className='btn btn-default' onClick={(e) => { this.onClick(e) }}>{this.props.buttons[2]}</a>
           </td>
         </tr>
       );

--- a/app/javascript/packs/tiny_mce.js
+++ b/app/javascript/packs/tiny_mce.js
@@ -45,6 +45,7 @@ $(() => {
       theme_advanced_statusbar_location: 'bottom',
       theme_advanced_buttons3_add: ['tablecontrols', 'fullscreen'],
       automatic_uploads: true,
+      content_css: '/packs/tiny_mce_style.css',
       images_upload_handler: (blobInfo, success, failure) => {
         const formData = new FormData();
         formData.append('file', blobInfo.blob(), blobInfo.filename());
@@ -65,7 +66,7 @@ $(() => {
                'visualchars, visualblocks, preview, table, fullscreen, lists, advlist, textcolor, emoticons, charmap image',
       toolbar: [
         'bold italic underline | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | fullscreen charmap',
-        'image reference'
+        'image reference container blank'
       ],
       setup: (editor) => {
         editor.addButton('reference', {
@@ -108,6 +109,27 @@ $(() => {
                 });
               }
             });
+          }
+        });
+        editor.addButton('container', {
+          tooltip: 'Insert container (red: Japanese, blue: English)',
+          icon: 'icon-double-arrow',
+          onclick: function() {
+            editor.insertContent(
+              `<div class="container" contenteditable='true'>
+                <div class="japanese"><p>&nbsp;</p></div>
+                <div class="english"><p>&nbsp;</p></div>
+                <div class="space"><p>&nbsp;</p></div>
+              </div>`
+            );
+          }
+        });
+        editor.addButton('blank', {
+          tooltip: 'Insert blank after selected container',
+          icon: 'icon-arrow',
+          onclick: function() {
+            let node = tinymce.get('form-tinymce').selection.getNode();
+            $(node).closest('.container').append('<div class="space"><p>&nbsp;</p></div>');
           }
         });
         editor.on('change', () => {

--- a/app/javascript/packs/tiny_mce.js
+++ b/app/javascript/packs/tiny_mce.js
@@ -118,8 +118,8 @@ $(() => {
           onclick: function() {
             editor.insertContent(
               `<div class="container" contenteditable='true'>
-                <div class="japanese"><p>&nbsp;</p></div>
-                <div class="english"><p>&nbsp;</p></div>
+                <div class="ja"><p>&nbsp;</p></div>
+                <div class="en"><p>&nbsp;</p></div>
                 <div class="space"><p>&nbsp;</p></div>
               </div>`
             );

--- a/app/javascript/packs/tiny_mce.js
+++ b/app/javascript/packs/tiny_mce.js
@@ -32,6 +32,7 @@ require.context(
 
 $(() => {
   let textIsChanged = false;
+  const cssPath = `${(process.env.RAILS_ENV == 'test') ? '/packs-test' : '/packs'}/tiny_mce_style.css`;
 
   if ($('textarea.tinymce').length > 0) {
     const CREATE_URL = `/protocols/${$('.tiny-mce-params').data('protocol-id')}/contents/${$('.tiny-mce-params').data('content-id')}/images`;
@@ -45,7 +46,7 @@ $(() => {
       theme_advanced_statusbar_location: 'bottom',
       theme_advanced_buttons3_add: ['tablecontrols', 'fullscreen'],
       automatic_uploads: true,
-      content_css: '/packs/tiny_mce_style.css',
+      content_css: cssPath,
       images_upload_handler: (blobInfo, success, failure) => {
         const formData = new FormData();
         formData.append('file', blobInfo.blob(), blobInfo.filename());

--- a/app/javascript/packs/tiny_mce_style.css
+++ b/app/javascript/packs/tiny_mce_style.css
@@ -1,0 +1,37 @@
+.japanese {
+  border: 1px dashed red;
+  margin: 5px;
+  padding: 5px;
+  width: 100%;
+}
+
+.english {
+  border: 1px dashed blue;
+  margin: 5px;
+  padding: 5px;
+  width: 100%;
+}
+
+table {
+  border: solid 1px #000000;
+  border-collapse: collapse;
+  td {
+    border: solid 1px #000000;
+  }
+}
+
+h3 {
+  font-size: 15px;
+  border-top: solid #4f818d 1px;
+  border-left: solid #4f818d 1px;
+  padding: 3px;
+  color: #4f818d;
+}
+
+h4 {
+  font-size: 13px;
+  border-top: dashed #4f818d 1px;
+  border-left: dashed #4f818d 1px;
+  padding: 3px;
+  color: #4f818d;
+}

--- a/app/javascript/packs/tiny_mce_style.css
+++ b/app/javascript/packs/tiny_mce_style.css
@@ -1,11 +1,11 @@
-.japanese {
+.ja {
   border: 1px dashed red;
   margin: 5px;
   padding: 5px;
   width: 100%;
 }
 
-.english {
+.en {
   border: 1px dashed blue;
   margin: 5px;
   padding: 5px;

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -5,7 +5,7 @@ class Ability
     user ||= User.new
 
     can :create, Protocol
-    can [:read, :clone, :export], Protocol, participations: { user_id: user.id }
+    can [:read, :clone, :export, :select], Protocol, participations: { user_id: user.id }
     can [:destroy, :build_team_form, :add_team, :admin], Protocol do |protocol|
       protocol.admin?(user)
     end

--- a/app/models/content.rb
+++ b/app/models/content.rb
@@ -37,6 +37,7 @@ class Content < ApplicationRecord
         i['src'] = Image.find(image_id).file.expiring_url(10.minutes)
       end
     end
+    # doc.xpath("//div[@class='japanese']").remove
     doc.at('body').children.to_s
   end
 

--- a/app/models/content.rb
+++ b/app/models/content.rb
@@ -24,7 +24,7 @@ class Content < ApplicationRecord
     end
   end
 
-  def replaced_body
+  def replaced_body(type)
     return body if body.empty? || !editable?
 
     doc = Nokogiri::HTML(body)
@@ -37,7 +37,11 @@ class Content < ApplicationRecord
         i['src'] = Image.find(image_id).file.expiring_url(10.minutes)
       end
     end
-    # doc.xpath("//div[@class='japanese']").remove
+    if type == 'english'
+      doc.xpath("//div[@class='japanese']").remove
+    elsif type == 'japanese'
+      doc.xpath("//div[@class='english']").remove
+    end
     doc.at('body').children.to_s
   end
 

--- a/app/models/content.rb
+++ b/app/models/content.rb
@@ -24,7 +24,7 @@ class Content < ApplicationRecord
     end
   end
 
-  def replaced_body(type)
+  def replaced_body(language)
     return body if body.empty? || !editable?
 
     doc = Nokogiri::HTML(body)
@@ -37,9 +37,9 @@ class Content < ApplicationRecord
         i['src'] = Image.find(image_id).file.expiring_url(10.minutes)
       end
     end
-    if type == 'english'
+    if language == 'en'
       doc.xpath("//div[@class='ja']").remove
-    elsif type == 'japanese'
+    elsif language == 'ja'
       doc.xpath("//div[@class='en']").remove
     end
     doc.at('body').children.to_s

--- a/app/models/content.rb
+++ b/app/models/content.rb
@@ -38,9 +38,9 @@ class Content < ApplicationRecord
       end
     end
     if type == 'english'
-      doc.xpath("//div[@class='japanese']").remove
+      doc.xpath("//div[@class='ja']").remove
     elsif type == 'japanese'
-      doc.xpath("//div[@class='english']").remove
+      doc.xpath("//div[@class='en']").remove
     end
     doc.at('body').children.to_s
   end

--- a/app/serializers/protocol_serializer.rb
+++ b/app/serializers/protocol_serializer.rb
@@ -1,6 +1,6 @@
 class ProtocolSerializer < BaseSerializer
   attributes :id, :title, :my_role, :principal_investigator, :status, :version,
-             :show_url, :export_pdf_url, :export_docx_url, :clone_url, :section_url
+             :show_url, :export_url, :clone_url, :section_url
 
   def my_role
     object.my_role(@instance_options[:user])
@@ -14,12 +14,8 @@ class ProtocolSerializer < BaseSerializer
     url_helpers.protocol_path(object)
   end
 
-  def export_pdf_url
-    object.finalized? ? url_helpers.export_protocol_path(object, format: :pdf) : ''
-  end
-
-  def export_docx_url
-    object.finalized? ? url_helpers.export_protocol_path(object, format: :docx) : ''
+  def export_url
+    object.finalized? ? url_helpers.select_protocol_path(object) : ''
   end
 
   def clone_url

--- a/app/views/protocols/_document.html.slim
+++ b/app/views/protocols/_document.html.slim
@@ -42,4 +42,4 @@ pre.mt-xl
     h3 class="#{content.no.include?('.') ? 'section-sub-title' : 'section-title' }"
       = "#{content.no} #{content.title}"
     .section-content
-      = content.replaced_body(params[:type]).html_safe
+      = content.replaced_body(params[:language]).html_safe

--- a/app/views/protocols/_document.html.slim
+++ b/app/views/protocols/_document.html.slim
@@ -42,4 +42,4 @@ pre.mt-xl
     h3 class="#{content.no.include?('.') ? 'section-sub-title' : 'section-title' }"
       = "#{content.no} #{content.title}"
     .section-content
-      = content.replaced_body.html_safe
+      = content.replaced_body(params[:type]).html_safe

--- a/app/views/protocols/select.html.slim
+++ b/app/views/protocols/select.html.slim
@@ -8,7 +8,7 @@
                                    class: 'btn btn-default', target: '_blank'
     = link_to t('.english_only'), export_protocol_path(@protocol, format: :pdf, language: 'en'),
                                   class: 'btn btn-default ml-m', target: '_blank'
-    = link_to t('.both'), export_protocol_path(@protocol, format: :pdf, language: 'both'),
+    = link_to t('.both'), export_protocol_path(@protocol, format: :pdf),
                           class: 'btn btn-default ml-m', target: '_blank'
 
   hr
@@ -20,7 +20,7 @@
                                   class: 'btn btn-default', target: '_blank'
     = link_to t('.english_only'), export_protocol_path(@protocol, format: :docx, language: 'en'),
                                  class: 'btn btn-default ml-m', target: '_blank'
-    = link_to t('.both'), export_protocol_path(@protocol, format: :docx, type: 'both'),
+    = link_to t('.both'), export_protocol_path(@protocol, format: :docx),
                          class: 'btn btn-default ml-m', target: '_blank'
 
   .mt-xl

--- a/app/views/protocols/select.html.slim
+++ b/app/views/protocols/select.html.slim
@@ -4,11 +4,11 @@
   .mt-xl
     b = t('.export_pdf')
   .mt-m
-    = link_to t('.japanese_only'), export_protocol_path(@protocol, format: :pdf, type: 'japanese'),
+    = link_to t('.japanese_only'), export_protocol_path(@protocol, format: :pdf, language: 'ja'),
                                    class: 'btn btn-default', target: '_blank'
-    = link_to t('.english_only'), export_protocol_path(@protocol, format: :pdf, type: 'english'),
+    = link_to t('.english_only'), export_protocol_path(@protocol, format: :pdf, language: 'en'),
                                   class: 'btn btn-default ml-m', target: '_blank'
-    = link_to t('.both'), export_protocol_path(@protocol, format: :pdf, type: 'both'),
+    = link_to t('.both'), export_protocol_path(@protocol, format: :pdf, language: 'both'),
                           class: 'btn btn-default ml-m', target: '_blank'
 
   hr
@@ -16,9 +16,9 @@
   .mt-xl
     b = t('.export_docx')
   .mt-m
-    = link_to t('.japanese_only'), export_protocol_path(@protocol, format: :docx, type: 'japanese'),
+    = link_to t('.japanese_only'), export_protocol_path(@protocol, format: :docx, language: 'ja'),
                                   class: 'btn btn-default', target: '_blank'
-    = link_to t('.english_only'), export_protocol_path(@protocol, format: :docx, type: 'english'),
+    = link_to t('.english_only'), export_protocol_path(@protocol, format: :docx, language: 'en'),
                                  class: 'btn btn-default ml-m', target: '_blank'
     = link_to t('.both'), export_protocol_path(@protocol, format: :docx, type: 'both'),
                          class: 'btn btn-default ml-m', target: '_blank'

--- a/app/views/protocols/select.html.slim
+++ b/app/views/protocols/select.html.slim
@@ -1,0 +1,23 @@
+.col-md-12
+  h3 = t('.title')
+
+  .form-group.mt-xl
+    .radio-inline
+      = radio_button_tag :export_type, 'english', checked: true
+      = label_tag :export_type_english, t('.english_only'), class: 'control-label'
+    .radio-inline
+      = radio_button_tag :export_type, 'japanese'
+      = label_tag :export_type_japanese, t('.japanese_only'), class: 'control-label'
+    .radio-inline
+      = radio_button_tag :export_type, 'both'
+      = label_tag :export_type_both,  t('.both'), class: 'control-label'
+  .form-group.mt-xl
+    - pdf_url = export_protocol_path(@protocol, format: :pdf)
+    = link_to t('.export_pdf'), "#{pdf_url}?type=english", data: { url: pdf_url },
+              class: 'btn btn-default export-pdf-button', target: '_blank'
+    - docx_url = export_protocol_path(@protocol, format: :docx)
+    = link_to t('.export_docx'), "#{docx_url}?type=english", data: { url: docx_url },
+              class: 'btn btn-default ml-s export-docx-button', target: '_blank'
+
+  .pull-left.mt-xl
+    = link_to t('.back'), :back, class: 'btn btn-default'

--- a/app/views/protocols/select.html.slim
+++ b/app/views/protocols/select.html.slim
@@ -1,23 +1,27 @@
 .col-md-12
   h3 = t('.title')
 
-  .form-group.mt-xl
-    .radio-inline
-      = radio_button_tag :export_type, 'english', checked: true
-      = label_tag :export_type_english, t('.english_only'), class: 'control-label'
-    .radio-inline
-      = radio_button_tag :export_type, 'japanese'
-      = label_tag :export_type_japanese, t('.japanese_only'), class: 'control-label'
-    .radio-inline
-      = radio_button_tag :export_type, 'both'
-      = label_tag :export_type_both,  t('.both'), class: 'control-label'
-  .form-group.mt-xl
-    - pdf_url = export_protocol_path(@protocol, format: :pdf)
-    = link_to t('.export_pdf'), "#{pdf_url}?type=english", data: { url: pdf_url },
-              class: 'btn btn-default export-pdf-button', target: '_blank'
-    - docx_url = export_protocol_path(@protocol, format: :docx)
-    = link_to t('.export_docx'), "#{docx_url}?type=english", data: { url: docx_url },
-              class: 'btn btn-default ml-s export-docx-button', target: '_blank'
+  .mt-xl
+    b = t('.export_pdf')
+  .mt-m
+    = link_to t('.japanese_only'), export_protocol_path(@protocol, format: :pdf, type: 'japanese'),
+                                   class: 'btn btn-default', target: '_blank'
+    = link_to t('.english_only'), export_protocol_path(@protocol, format: :pdf, type: 'english'),
+                                  class: 'btn btn-default ml-m', target: '_blank'
+    = link_to t('.both'), export_protocol_path(@protocol, format: :pdf, type: 'both'),
+                          class: 'btn btn-default ml-m', target: '_blank'
 
-  .pull-left.mt-xl
+  hr
+
+  .mt-xl
+    b = t('.export_docx')
+  .mt-m
+    = link_to t('.japanese_only'), export_protocol_path(@protocol, format: :docx, type: 'japanese'),
+                                  class: 'btn btn-default', target: '_blank'
+    = link_to t('.english_only'), export_protocol_path(@protocol, format: :docx, type: 'english'),
+                                 class: 'btn btn-default ml-m', target: '_blank'
+    = link_to t('.both'), export_protocol_path(@protocol, format: :docx, type: 'both'),
+                         class: 'btn btn-default ml-m', target: '_blank'
+
+  .mt-xl
     = link_to t('.back'), :back, class: 'btn btn-default'

--- a/app/views/protocols/show.html.slim
+++ b/app/views/protocols/show.html.slim
@@ -67,8 +67,7 @@
 
   - if can? :admin, @protocol
     = link_to t('.edit'), edit_protocol_path(@protocol), class: 'btn btn-default'
-    = link_to t('.export_pdf'), export_protocol_path(@protocol, format: :pdf), class: 'btn btn-default ml-s', target: '_blank'
-    = link_to t('.export_docx'), export_protocol_path(@protocol, format: :docx), class: 'btn btn-default ml-s', target: '_blank'
+    = link_to t('.export'), select_protocol_path(@protocol), class: 'btn btn-default ml-s'
     - unless @protocol.finalized?
       = link_to t('.finalize'), finalize_protocol_path(@protocol), class: 'btn btn-default ml-s',
                                 data: { confirm: t('.finalize_text') }

--- a/config/locales/views/protocols.en.yml
+++ b/config/locales/views/protocols.en.yml
@@ -186,6 +186,6 @@ en:
       japanese_only: Output in Japanese only
       english_only: Output in English only
       both: Both outputs
-      export_pdf: Export(.pdf)
-      export_docx: Export(.docx)
+      export_pdf: pdf file
+      export_docx: docx file
       back: Back

--- a/config/locales/views/protocols.en.yml
+++ b/config/locales/views/protocols.en.yml
@@ -14,8 +14,7 @@ en:
         - ''
       buttons:
         - Details
-        - Export(.pdf)
-        - Export(.docx)
+        - Export
         - Clone
     new:
       title: New protocol
@@ -36,8 +35,7 @@ en:
       updated_at: Updated at
       compliance: Statement of Compliance
       no_select: Compliance is not selected
-      export_pdf: Export(.pdf)
-      export_docx: Export(.docx)
+      export: Export
       finalize: Finalize
       finalize_text: Do you want to finalize this protocol?
       reinstate: Reinstate
@@ -183,3 +181,11 @@ en:
       draft_number: Draft number
       table_of_contents: Table of Contents
       compliance: Statement of Compliance
+    select:
+      title: Export
+      japanese_only: Output in Japanese only
+      english_only: Output in English only
+      both: Both outputs
+      export_pdf: Export(.pdf)
+      export_docx: Export(.docx)
+      back: Back

--- a/config/locales/views/protocols.ja.yml
+++ b/config/locales/views/protocols.ja.yml
@@ -14,8 +14,7 @@ ja:
         - ''
       buttons:
         - 詳細
-        - エクスポート(.pdf)
-        - エクスポート(.docx)
+        - エクスポート
         - 複製
     new:
       title: プロトコル新規作成
@@ -36,8 +35,7 @@ ja:
       updated_at: 更新日時
       compliance: コンプライアンス声明
       no_select: コンプライアンスが選択されていません。
-      export_pdf: エクスポート(.pdf)
-      export_docx: エクスポート(.docx)
+      export: エクスポート
       finalize: 正式版として承認
       finalize_text: このプロトコルを正式版として承認しますか？
       reinstate: 再編集
@@ -179,3 +177,11 @@ ja:
       draft_number: バージョン
       table_of_contents: 目次
       compliance: コンプライアンス
+    select:
+      title: エクスポート
+      japanese_only: 日本語のみ出力
+      english_only: 英語のみ出力
+      both: 両方出力
+      export_pdf: エクスポート(.pdf)
+      export_docx: エクスポート(.docx)
+      back: 戻る

--- a/config/locales/views/protocols.ja.yml
+++ b/config/locales/views/protocols.ja.yml
@@ -182,6 +182,6 @@ ja:
       japanese_only: 日本語のみ出力
       english_only: 英語のみ出力
       both: 両方出力
-      export_pdf: エクスポート(.pdf)
-      export_docx: エクスポート(.docx)
+      export_pdf: pdfファイル
+      export_docx: docxファイル
       back: 戻る

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,7 +23,7 @@ Rails.application.routes.draw do
     end
 
     member do
-      get :clone, :export, :finalize, :reinstate
+      get :clone, :export, :finalize, :reinstate, :select
     end
   end
 

--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -1,10 +1,17 @@
 const { environment } = require('@rails/webpacker')
 const webpack = require('webpack')
+const ExtractTextPlugin = require('extract-text-webpack-plugin')
+
+environment.plugins.append(
+  'ExtractTextPlugin',
+  new ExtractTextPlugin("[name].css")
+)
 
 module.exports = Object.assign({}, environment.toWebpackConfig(), {
   entry: {
     main: './app/javascript/packs/main.js',
-    export: './app/javascript/packs/export.js'
+    export: './app/javascript/packs/export.js',
+    tiny_mce_style: './app/javascript/packs/tiny_mce_style.css'
   },
   module: {
     loaders: [
@@ -23,6 +30,13 @@ module.exports = Object.assign({}, environment.toWebpackConfig(), {
       {
         test: /tinymce\/(themes|plugins)\//,
         loader: 'imports-loader?this=>window'
+      },
+      {
+        test: /tiny_mce_style.css/,
+        exclude: /node_modules/,
+        use: ExtractTextPlugin.extract({
+          use: ['css-loader']
+        })
       }
     ]
   },

--- a/spec/controllers/protocols_controller_spec.rb
+++ b/spec/controllers/protocols_controller_spec.rb
@@ -185,4 +185,14 @@ describe ProtocolsController, type: :controller do
       end
     end
   end
+
+  describe '#select' do
+    context 'all user' do
+      let(:current_user) { general_user }
+      it 'renders the select template' do
+        get :select, params: { id: protocol0 }
+        expect(response).to render_template :select
+      end
+    end
+  end
 end

--- a/spec/features/protocols_spec.rb
+++ b/spec/features/protocols_spec.rb
@@ -83,7 +83,7 @@ feature Protocol, js: true do
   shared_examples_for 'exports protocol' do
     scenario 'pdf' do
       visit select_protocol_path(protocol1)
-      click_on 'Export(.pdf)'
+      all('.btn', text: 'Output in Japanese only').first.click
 
       handle = page.driver.browser.window_handles.last
       page.driver.browser.within_window(handle) do
@@ -92,22 +92,12 @@ feature Protocol, js: true do
     end
     scenario 'docx' do
       visit select_protocol_path(protocol1)
-      click_on 'Export(.docx)'
+      all('.btn', text: 'Output in Japanese only').last.click
 
       handle = page.driver.browser.window_handles.last
       page.driver.browser.within_window(handle) do
         expect(page.response_headers['Content-Type']).to eq('application/vnd.openxmlformats-officedocument.wordprocessingml.document')
       end
-    end
-    scenario 'selects export_type' do
-      visit select_protocol_path(protocol1)
-      base_href = export_protocol_path(protocol1, format: 'pdf')
-      choose 'export_type_english'
-      expect(page).to have_link(nil, href: "#{base_href}?type=english")
-      choose 'export_type_japanese'
-      expect(page).to have_link(nil, href: "#{base_href}?type=japanese")
-      choose 'export_type_both'
-      expect(page).to have_link(nil, href: "#{base_href}?type=both")
     end
   end
 

--- a/spec/features/protocols_spec.rb
+++ b/spec/features/protocols_spec.rb
@@ -71,24 +71,43 @@ feature Protocol, js: true do
     end
   end
 
-  shared_examples_for 'can export protocol (status is finalized)' do
-    scenario 'pdf' do
+  shared_examples_for 'moves to export page (status is finalized)' do
+    scenario do
       within(:xpath, "//tr[td[contains(., '#{protocol1.title}')]]") do
-        click_on 'Export(.pdf)'
+        click_on 'Export'
       end
+      expect(current_path).to eq select_protocol_path(protocol1)
+    end
+  end
+
+  shared_examples_for 'exports protocol' do
+    scenario 'pdf' do
+      visit select_protocol_path(protocol1)
+      click_on 'Export(.pdf)'
+
       handle = page.driver.browser.window_handles.last
       page.driver.browser.within_window(handle) do
         expect(page.response_headers['Content-Type']).to eq('application/pdf')
       end
     end
     scenario 'docx' do
-      within(:xpath, "//tr[td[contains(., '#{protocol1.title}')]]") do
-        click_on 'Export(.docx)'
-      end
+      visit select_protocol_path(protocol1)
+      click_on 'Export(.docx)'
+
       handle = page.driver.browser.window_handles.last
       page.driver.browser.within_window(handle) do
         expect(page.response_headers['Content-Type']).to eq('application/vnd.openxmlformats-officedocument.wordprocessingml.document')
       end
+    end
+    scenario 'selects export_type' do
+      visit select_protocol_path(protocol1)
+      base_href = export_protocol_path(protocol1, format: 'pdf')
+      choose 'export_type_english'
+      expect(page).to have_link(nil, href: "#{base_href}?type=english")
+      choose 'export_type_japanese'
+      expect(page).to have_link(nil, href: "#{base_href}?type=japanese")
+      choose 'export_type_both'
+      expect(page).to have_link(nil, href: "#{base_href}?type=both")
     end
   end
 
@@ -99,7 +118,8 @@ feature Protocol, js: true do
     it_should_behave_like 'can move to show protocol page'
     it_should_behave_like 'can move to show contents page'
     it_should_behave_like 'can clone protocol'
-    it_should_behave_like 'can export protocol (status is finalized)'
+    it_should_behave_like 'moves to export page (status is finalized)'
+    it_should_behave_like 'exports protocol'
 
     scenario 'can edit protocol' do
       visit(protocol_path(protocol0))
@@ -116,22 +136,10 @@ feature Protocol, js: true do
 
     scenario 'can export protocol (in details page)' do
       visit(protocol_path(protocol0))
-      expect(page).to have_link 'Export(.pdf)'
+      expect(page).to have_link 'Export'
 
-      click_on 'Export(.pdf)'
-      handle = page.driver.browser.window_handles.last
-      page.driver.browser.within_window(handle) do
-        expect(page.response_headers['Content-Type']).to eq('application/pdf')
-      end
-
-      visit(protocol_path(protocol0))
-      expect(page).to have_link 'Export(.docx)'
-
-      click_on 'Export(.docx)'
-      handle = page.driver.browser.window_handles.last
-      page.driver.browser.within_window(handle) do
-        expect(page.response_headers['Content-Type']).to eq('application/vnd.openxmlformats-officedocument.wordprocessingml.document')
-      end
+      click_on 'Export'
+      expect(current_path).to eq select_protocol_path(protocol0)
     end
 
     scenario 'can change status to finalized' do
@@ -160,7 +168,8 @@ feature Protocol, js: true do
     it_should_behave_like 'can move to show protocol page'
     it_should_behave_like 'can move to show contents page'
     it_should_behave_like 'can clone protocol'
-    it_should_behave_like 'can export protocol (status is finalized)'
+    it_should_behave_like 'moves to export page (status is finalized)'
+    it_should_behave_like 'exports protocol'
 
     scenario 'can not edit protocol' do
       visit(protocol_path(protocol0))


### PR DESCRIPTION
#43 
#3 

- tinymceにカスタムプラグインを追加
  - 日本語用と英語用、２つの色違い枠線付きdivが挿入されるボタン
  - 上記ボタンで末尾に挿入される空行（空div）を消すと空行を再挿入できないことがある（間にテキストを挿入したくてもできなくなる）ので、空行だけ挿入するボタン
- tinymceにcssを適用
- 日本語と英語のどちらかまたは両方でエクスポートできるよう、エクスポート選択用画面の追加
- specの追加、修正

@katsusuke 確認をお願いします。
なお、日本語のみ、英語のみ、両方とも、のエクスポートはローカルで手動でのみですが確認できています。