### PR TITLE
Fix model

### DIFF
--- a/app/models/concerns/section_module.rb
+++ b/app/models/concerns/section_module.rb
@@ -3,7 +3,12 @@ module SectionModule
 
   included do
     default_scope { order(:no, :seq) }
-    scope :root, -> { find_by(no: 0) }
+  end
+
+  module ClassMethods
+    def root
+      find_by(no: 0)
+    end
   end
 
   def no_seq

--- a/spec/models/content_spec.rb
+++ b/spec/models/content_spec.rb
@@ -2,11 +2,17 @@ require 'rails_helper'
 
 describe Content do
   let(:protocol) { create(:protocol) }
+  let(:jccg_protocol) { create(:protocol, template_name: 'JCCG') }
   let(:reviewer) { create(:user) }
   let!(:reviewer_participation) { create(:reviewer, protocol: protocol, user: reviewer, sections: [0]) }
 
   context 'has_reviewer?' do
     it { expect(protocol.contents.root.has_reviewer?).to eq(true) }
     it { expect(protocol.contents.find_by(no: 1, seq: 0).has_reviewer?).to eq(false) }
+  end
+
+  context 'return root section' do
+    it { expect(protocol.contents.root.no).to eq(0) }
+    it { expect(jccg_protocol.contents.root).to eq(nil) }
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -93,4 +93,5 @@ RSpec.configure do |config|
   # as the one that triggered the failure.
   Kernel.srand config.seed
 =end
+  config.order = :random
 end


### PR DESCRIPTION
protocol.contents.rootで該当するレコードがない時にはnilが欲しいところ、
allが返ってきてバグの原因となっていたのでスコープからクラスメソッドに変更しました。

確認をお願いします。
@katsusuke 